### PR TITLE
Pin google-beta provider version.

### DIFF
--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -5,6 +5,7 @@ provider "google" {
 }
 
 provider "google-beta" {
+  version     = "~> 3.73.0"
   project     = var.project
   region      = var.region
 }

--- a/terraform/prod/main.tf
+++ b/terraform/prod/main.tf
@@ -5,6 +5,7 @@ provider "google" {
 }
 
 provider "google-beta" {
+  version     = "~> 3.73.0"
   project     = var.project
   region      = var.region
 }


### PR DESCRIPTION
Version v4.0.0 of the `google-beta` provider removed the `master_auth.username` and `master_auth.password` fields from the `google_container_cluster` resource (https://github.com/hashicorp/terraform-provider-google/releases). This causes problems with the CloudKite gke module used (https://github.com/cloudkite-io/terraform-modules/blob/v0.0.4/modules/gcp/gke/main.tf , but the same thing happens with the latest version of the module). This PR pins the `google-beta` version.